### PR TITLE
Increases max-old-space-size

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: Relative path under $GITHUB_WORKSPACE where the project is located.
     required: false
     default: "."
+  max-memory:
+    description: Max old space size (in megabytes)
+    required: false
+    default: 4096
 
 runs:
   using: composite
@@ -48,6 +52,8 @@ runs:
     - name: Run Jest
       shell: bash
       working-directory: ${{ steps.context.outputs.working-directory }}
+      env:
+        NODE_OPTIONS: "--max-old-space-size=${{ inputs.max-memory }}"
       run: yarn ${{ inputs.task-name }}
 
     - name: Upload report


### PR DESCRIPTION
Les tests fail avec node 16 dans le cpanel2.
https://github.com/kronostechnologies/cpanel2/runs/6210457461?check_suite_focus=true
`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`

J'ai pas trouvé la valeur par défaut officiel de max-old-space-size ni la quantité de mémoire disponible dans un github action. Mais j'ai vu que certains recommandaient 4go. J'imagine qu'on pourrait ajouter un input pour ça.